### PR TITLE
fix: the atenl ethernet initialization code copies a... in eth.c

### DIFF
--- a/feed/app/atenl/src/eth.c
+++ b/feed/app/atenl/src/eth.c
@@ -15,7 +15,7 @@ int atenl_eth_init(struct atenl *an)
 		goto out;
 	}
 
-	memcpy(ifr.ifr_name, an->bridge_name, strlen(an->bridge_name));
+	memcpy(ifr.ifr_name, an->bridge_name, strnlen(an->bridge_name, IFNAMSIZ - 1));
 	ret = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_RACFG));
 	if (ret < 0) {
 		perror("socket");


### PR DESCRIPTION
## Summary
Fix high severity security issue in `feed/app/atenl/src/eth.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `feed/app/atenl/src/eth.c:18` |

**Description**: The atenl Ethernet initialization code copies a bridge interface name into the ifr_name field of a struct ifreq using strlen(an->bridge_name) as the copy length. The ifr_name field is defined by the Linux kernel as IFNAMSIZ (16 bytes). Because the source length is used instead of the destination buffer size, any bridge_name longer than 16 bytes overflows the stack buffer, corrupting adjacent memory including potential return addresses and function pointers.

## Changes
- `feed/app/atenl/src/eth.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
